### PR TITLE
adapt to sonar.version 5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
   <properties>
     <sonar.pluginName>PDF Report</sonar.pluginName>
     <sonar.pluginClass>org.sonar.report.pdf.plugin.PDFReportPlugin</sonar.pluginClass>
-    <sonar.version>4.5.1</sonar.version>
+    <sonar.version>5.1</sonar.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/sonar/report/pdf/builder/ProjectBuilder.java
+++ b/src/main/java/org/sonar/report/pdf/builder/ProjectBuilder.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.dom4j.DocumentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.utils.HttpDownloader.HttpException;

--- a/src/main/java/org/sonar/report/pdf/builder/RuleBuilder.java
+++ b/src/main/java/org/sonar/report/pdf/builder/RuleBuilder.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.dom4j.DocumentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.utils.HttpDownloader.HttpException;
@@ -35,6 +34,7 @@ import org.sonar.report.pdf.entity.exception.ReportException;
 import org.sonar.report.pdf.util.Credentials;
 import org.sonar.wsclient.Sonar;
 import org.sonar.wsclient.SonarClient;
+import org.sonar.wsclient.internal.EncodingUtils;
 import org.sonar.wsclient.issue.Issue;
 import org.sonar.wsclient.issue.IssueClient;
 import org.sonar.wsclient.issue.IssueQuery;
@@ -80,7 +80,6 @@ public class RuleBuilder {
    * 
    * @return
    * @throws UnsupportedEncodingException
-   * @throws DocumentException
    * @throws IOException
    * @throws HttpException
    */
@@ -97,7 +96,9 @@ public class RuleBuilder {
       IssueClient issueClient = client.issueClient();
 
       IssueQuery issueQuery = IssueQuery.create();
-      issueQuery.componentRoots(projectKey);
+      // because the ws method is not implemeted in ws client api/search/issues client API
+      issueQuery.urlParams().put("componentKeys", EncodingUtils.toQueryParam(new String[]{projectKey}));
+      issueQuery.onComponentOnly(false);
       issueQuery.pageSize(20);
       issueQuery.rules(ruleKey);
       // "&scopes=FIL&depth=-1&limit=20

--- a/src/test/java/org/sonar/report/pdf/test/PDFPostJobTest.java
+++ b/src/test/java/org/sonar/report/pdf/test/PDFPostJobTest.java
@@ -42,7 +42,7 @@ public class PDFPostJobTest {
   public void before() {
     project = mock(Project.class);
     settings = mock(Settings.class);
-    fs = new DefaultFileSystem();
+    fs = mock(DefaultFileSystem.class);
     pdfPostJob = new PDFPostJob(settings, fs);
   }
 


### PR DESCRIPTION
it seems that your upgrade to sonar api 5.x continue to use the 4.5.1 api 

be carefull there is a hack in org\sonar\report\pdf\builder\RuleBuilder.java :
- the api remove componentRoots from ws api search/issue (still accessible but deprecated in sonarqube server 5.1) it is replace by componentKeys
- the api in the IssueQuery does not expose parameter componentKeys

pom.xml
![image](https://cloud.githubusercontent.com/assets/977031/7332947/f6451df2-eb5a-11e4-83ab-8553498a74de.png)

org\sonar\report\pdf\builder\RuleBuilder.java : 
![image](https://cloud.githubusercontent.com/assets/977031/7332948/100f4352-eb5b-11e4-80b2-80b8016f8582.png)
